### PR TITLE
Support tomlkit 0.7.2

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -176,7 +176,7 @@ python-versions = "*"
 
 [[package]]
 name = "tomlkit"
-version = "0.7.0"
+version = "0.7.2"
 description = "Style preserving TOML library"
 category = "main"
 optional = false
@@ -314,8 +314,8 @@ toml = [
     {file = "toml-0.10.1.tar.gz", hash = "sha256:926b612be1e5ce0634a2ca03470f95169cf16f939018233a670519cb4ac58b0f"},
 ]
 tomlkit = [
-    {file = "tomlkit-0.7.0-py2.py3-none-any.whl", hash = "sha256:6babbd33b17d5c9691896b0e68159215a9387ebfa938aa3ac42f4a4beeb2b831"},
-    {file = "tomlkit-0.7.0.tar.gz", hash = "sha256:ac57f29693fab3e309ea789252fcce3061e19110085aa31af5446ca749325618"},
+    {file = "tomlkit-0.7.2-py2.py3-none-any.whl", hash = "sha256:173ad840fa5d2aac140528ca1933c29791b79a374a0861a80347f42ec9328117"},
+    {file = "tomlkit-0.7.2.tar.gz", hash = "sha256:d7a454f319a7e9bd2e249f239168729327e4dd2d27b17dc68be264ad1ce36754"},
 ]
 typer = [
     {file = "typer-0.3.2-py3-none-any.whl", hash = "sha256:ba58b920ce851b12a2d790143009fa00ac1d05b3ff3257061ff69dbdfc3d161b"},

--- a/poetry_dev/__init__.py
+++ b/poetry_dev/__init__.py
@@ -75,7 +75,7 @@ def version():
     for name, req in dependencies.items():
         if isinstance(req, dict) and "path" in req and get_pyproject_path(pathlib.Path(req["path"])).exists():
             version_req = "^" + get_version(pathlib.Path(req["path"]))
-            changed_dependencies[name] = dependencies[name]
+            changed_dependencies[name] = dependencies[name].copy()
             del changed_dependencies[name]["path"]
             changed_dependencies[name]["version"] = req["version"] = version_req
             typer.echo(f"{name}: Changing path requirement ../{name} to version requirement {req['version']}")
@@ -95,7 +95,7 @@ def path(develop: bool = typer.Option(True, help="Install path dependencies in d
             dependencies[name] = req = {"version": req}
 
         if "path" not in req and get_pyproject_path(pathlib.Path("..") / name).exists():
-            changed_dependencies[name] = dependencies[name]
+            changed_dependencies[name] = dependencies[name].copy()
             del changed_dependencies[name]["version"]
             changed_dependencies[name]["path"] = f"../{name}"
             changed_dependencies[name]["develop"] = develop

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -11,17 +11,18 @@ from poetry_dev import app
 runner = CliRunner()
 
 
-def test_path(tmp_path: pathlib.Path, monkeypatch):
+@pytest.mark.parametrize("spec", ["\"0.1.0\"", "{version = \"0.1.0\"}"])
+def test_path(tmp_path: pathlib.Path, monkeypatch, spec: str):
 
     bar_pyproject_toml = tmp_path / "bar_pyproject_toml"
     bar_pyproject_toml.write_text(
-        """[tool.poetry]
+        f"""[tool.poetry]
 name = "bar"
 version = "0.2.0"
 
 [tool.poetry.dependencies]
 python = "^3.7"
-foo = "0.1.0"
+foo = {spec}
 
 [build-system]
 requires = ["poetry>=0.12"]
@@ -52,7 +53,7 @@ build-backend = "poetry.masonry.api"
     monkeypatch.setattr(poetry_dev, "get_pyproject_path", get_pyproject_path)
     monkeypatch.setattr(subprocess, "call", lambda _: None)
 
-    result = runner.invoke(app, ["path"])
+    result = runner.invoke(app, ["path"], catch_exceptions=False)
     assert result.exit_code == 0
     assert """foo = {path = "../foo", develop = true}""" in bar_pyproject_toml.read_text()
 

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -54,7 +54,7 @@ build-backend = "poetry.masonry.api"
 
     result = runner.invoke(app, ["path"])
     assert result.exit_code == 0
-    assert """foo = {path = "../foo"}""" in bar_pyproject_toml.read_text()
+    assert """foo = {path = "../foo", develop = true}""" in bar_pyproject_toml.read_text()
 
 
 def test_version(tmp_path: pathlib.Path, monkeypatch):


### PR DESCRIPTION
Tomlkit 0.7.2 introduces dict semantics for TOML tables, which means that values are returned by reference instead of by copy. This causes `poetry_dev path` to raise `NonExistantKey` when dependency specs are inline tables rather than strings. This PR bumps tomlkit to 0.7.2, adds a test case that uses inline-table dependencies, and a work-around to explicitly copy values before mutating them.