### PR TITLE
Unset develop property on version deps

### DIFF
--- a/poetry_dev/__init__.py
+++ b/poetry_dev/__init__.py
@@ -77,6 +77,7 @@ def version():
             version_req = "^" + get_version(pathlib.Path(req["path"]))
             changed_dependencies[name] = dependencies[name].copy()
             del changed_dependencies[name]["path"]
+            changed_dependencies[name].pop("develop")
             changed_dependencies[name]["version"] = req["version"] = version_req
             typer.echo(f"{name}: Changing path requirement ../{name} to version requirement {req['version']}")
 


### PR DESCRIPTION
After fc1fa1f2aa443a20b64721707be06acb89dbf6d6, round-trips of `poetry_dev path; poetry_dev version` began to fail with e.g.:

```
  RuntimeError

  The Poetry configuration is invalid:
    - [dependencies.foo] {'develop': True, 'version': '^0.8.0-alpha.1'} is not valid under any of the given schemas
```

Removing the `develop` property makes `poetry_dev` emit valid requirements again.